### PR TITLE
Fix Prince Malchezaar Equipment

### DIFF
--- a/scripts/eastern_kingdoms/karazhan/boss_prince_malchezaar.cpp
+++ b/scripts/eastern_kingdoms/karazhan/boss_prince_malchezaar.cpp
@@ -59,7 +59,8 @@ enum
     NPC_NETHERSPITE_INFERNAL    = 17646,                    // The netherspite infernal creature
     NPC_MALCHEZARS_AXE          = 17650,                    // Malchezar's axes summoned during phase 3
 
-    EQUIP_ID_AXE                = 23996,                    // Axes info
+    // EQUIP_ID_AXE             = 23996,                    // Axes info WotLK
+    EQUIP_ID_AXE                = 28767,                    // Axes info TBC
 
     ATTACK_TIMER_DEFAULT        = 2400,                     // note: for WotLK it is 2000
     ATTACK_TIMER_AXES           = 1600,                     // note: for WotLK it is 1333


### PR DESCRIPTION
On TBC we must use other id as wotlk need sql update

UPDATE creature_template SET EquipmentTemplateId = 2300 WHERE entry = 17650;
-- Use Entry 2300 from UDB but change the equipentry1 and equipentry2 WOTLK Use 23996
-- Need SD2 Change
DELETE FROM `creature_equip_template` WHERE entry = 2300;
INSERT INTO `creature_equip_template` (`entry`, `equipentry1`, `equipentry2`, `equipentry3`) VALUES
('2300','28767','28767','0');
